### PR TITLE
[BUG] or seems to me

### DIFF
--- a/Workflow.php
+++ b/Workflow.php
@@ -288,9 +288,12 @@ class Workflow
     {
         foreach ($transitions as $transition) {
             foreach ($transition->getFroms() as $place) {
-                if (!$marking->has($place)) {
-                    continue 2;
+                if ($marking->has($place)) {
+                    break;
                 }
+            }
+            if (!$marking->has($place)) {
+                continue 1;
             }
 
             if (true !== $this->guardTransition($subject, $marking, $transition)) {


### PR DESCRIPTION
As it, if i have a marking and a transition with the following data this continue without validate the transition. And , this seems logical because as it, the marking should have all froms for its wanted transition. I think this is a bug but maybe it is a thing that i don't tested in a good way. 

If it's a bug, i redraw this pull request by tests, clear explinations and a reformated issue.

```yaml
Workflow.php on line 290:
Marking {#6
  -places: array:1 [▼
    "initial" => 1
  ]
}
Workflow.php on line 290:
array:1 [▼
  0 => Transition {#548 ▼
    -name: "go_search"
    -froms: array:3 [▼
      0 => "initial"
      1 => "vehicles"
      2 => "informations"
    ]
    -tos: array:1 [▼
      0 => "search"
    ]
  }
]
```