### PR TITLE
allow tranfition from one of many "from" states

### DIFF
--- a/Workflow.php
+++ b/Workflow.php
@@ -252,12 +252,16 @@ class Workflow implements WorkflowInterface
 
     private function buildTransitionBlockerListForTransition($subject, Marking $marking, Transition $transition)
     {
+        $found = false;
         foreach ($transition->getFroms() as $place) {
-            if (!$marking->has($place)) {
-                return new TransitionBlockerList([
-                    TransitionBlocker::createBlockedByMarking($marking),
-                ]);
+            if ($marking->has($place)) {
+                $found = true;
             }
+        }
+        if(!$found){
+            return new TransitionBlockerList([
+                TransitionBlocker::createBlockedByMarking($marking),
+            ]);
         }
 
         if (null === $this->dispatcher) {


### PR DESCRIPTION
without this change I'm unable to make transition from one of three independent states

```
sample_transition:
      from:
          - FIRST
          - SECOND
          - THIRD
      to: FINAL_STATE
```
Transition THIRD->FINAL_STATE works only if workflow definition is as follows
```
sample_transition:
      from:
         - THIRD
          - FIRST
          - SECOND      
     to: FINAL_STATE
```
But transitions: FIRST->FINAL_STATE, SECOND->FINAL_STATE must be olso available.