### PR TITLE
Correctly constructing test to expose bug with extra guard event dispatched

### DIFF
--- a/Tests/WorkflowTest.php
+++ b/Tests/WorkflowTest.php
@@ -411,7 +411,7 @@ class WorkflowTest extends TestCase
     public function testApplyDoesNotTriggerExtraGuardWithEventDispatcher()
     {
         $transitions[] = new Transition('a-b', 'a', 'b');
-        $transitions[] = new Transition('a-c', 'a', 'c');
+        $transitions[] = new Transition('b-c', 'b', 'c');
         $definition = new Definition(['a', 'b', 'c'], $transitions);
 
         $subject = new Subject();


### PR DESCRIPTION
This is to show that the tests do not cover this bug correctly. The tests are expected to fail.