### PR TITLE
GuardEvent::getTransition() returns a Transition

### DIFF
--- a/Event/GuardEvent.php
+++ b/Event/GuardEvent.php
@@ -20,6 +20,8 @@ use Symfony\Component\Workflow\WorkflowInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @method Transition getTransition()
  */
 final class GuardEvent extends Event
 {


### PR DESCRIPTION
Since $transition is required on the constructor, we can type thint that getTransition always return the `Transition`, rather than `Transition|null`.

I'm also happy to update the other events that are only ever called with with a concrete Transition, if this is acceptable, however I need guidance on whether there's a change these could be called without the Transition in other uses, somehow, or not.